### PR TITLE
Fix links in Introduction

### DIFF
--- a/src/introduction.md
+++ b/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-[Bevy](https://bevyengine.org/) is a fantastic, free, open source, ECS-style game engine written in Rust. This book is [my](https://github.com/alice-i-cecile) attempt to collect, summarize and contextualize the engine and its ecosystem. This book was written for Bevy 0.4, and assumes familiarity with core Rust concepts (like lifetimes, traits, objects and iterators), but no previous experience with either Bevy or game programming as a whole. If you have any suggestions, questions, or spot an error, please feel free to open an issue on this site's [Github](https://github.com/alice-i-cecile/understanding-bevy.github.io).
+[Bevy](https://bevyengine.org/) is a fantastic, free, open source, ECS-style game engine written in Rust. This book is [my](https://github.com/alice-i-cecile) attempt to collect, summarize and contextualize the engine and its ecosystem. This book was written for Bevy 0.4, and assumes familiarity with core Rust concepts (like lifetimes, traits, objects and iterators), but no previous experience with either Bevy or game programming as a whole. If you have any suggestions, questions, or spot an error, please feel free to open an issue on this site's [Github](https://github.com/alice-i-cecile/understanding-bevy).
 
 This book is deliberately opinionated: rather than simply reiterating the API that Bevy offers you, it attempts to provide context on the options available and when you should reach for a particular tool. 
 Ideally, this book will teach how you should write elegant, performant and idiomatic game code in Bevy + Rust and Bevy and steer you away from obvious pitfalls that may seem tempting at first glance.
@@ -35,7 +35,7 @@ As you read along, there are a few key resources you should be aware of:
 
 - The [Bevy Book](https://bevyengine.org/learn/book/introduction/): a great example-driven introduction to the library
 
-- The [Bevy Rust API docs](https://docs.rs/bevy/0.3.0/bevy/): for looking up the details of a particular bit of code
+- The [Bevy Rust API docs](https://docs.rs/bevy/): for looking up the details of a particular bit of code
 
 - The [official Github](https://github.com/bevyengine/bevy): the source code is quite legible, and the issues, pull requests and discussions are where the serious engine development takes place
 


### PR DESCRIPTION
This PR fixes two links in the Introduction. The first one is the link to this repo, which doesn't work. The second one points to the 0.3 version of the Bevy docs. I've removed the version number from the link, which will make it always open the latest version.